### PR TITLE
Filename typo fix

### DIFF
--- a/plugins/ShopwareTasks/Dispatcher/PluginDeactivateDispatcher.php
+++ b/plugins/ShopwareTasks/Dispatcher/PluginDeactivateDispatcher.php
@@ -8,7 +8,7 @@ use Deployee\Plugins\RunDeploy\Dispatcher\AbstractTaskDefinitionDispatcher;
 use Deployee\Plugins\ShellTasks\Definitions\ShellTaskDefinition;
 use Deployee\Plugins\ShopwareTasks\Definitions\PluginDeactivateDefinition;
 
-class PluginDectivateDispatcher extends AbstractTaskDefinitionDispatcher
+class PluginDeactivateDispatcher extends AbstractTaskDefinitionDispatcher
 {
     /**
      * @param TaskDefinitionInterface $taskDefinition


### PR DESCRIPTION
Fix fatal-error by command:
`php bin/deployee deployee:install`

Error message:
`PHP Fatal error:  Uncaught Error: Class 'Deployee\Plugins\ShopwareTasks\Dispatcher\PluginDeactivateDispatcher' not found in /var/www/deployee/plugins/RunDeploy/Factory.php:38
`