### PR TITLE
Add path to main project

### DIFF
--- a/src/Config/Facade.php
+++ b/src/Config/Facade.php
@@ -49,7 +49,7 @@ class Facade extends AbstractFacade
      */
     private function findConfigFile()
     {
-        $searchInPaths = [getcwd()];
+        $searchInPaths = [getcwd(), __DIR__ . '/../../../../../'];
 
         if($envConfig = getenv('DEPLOYEE_CONFIG')){
             $envConfig = is_file($envConfig) ? dirname($envConfig) : $envConfig;


### PR DESCRIPTION
Config should be always check deployee.yml file in main-folder.

Example:
Path: /var/www/myproject
Project-tree:
- composer.json
- deployee.yml
- vendor/
      ....
      - phizzl/deployee/src/Config/Facade.php

deployee.yml is only read when i am in "/var/www/myproject"
This command: "/var/www/myproject/vendor/bin/deployee" dont works, when i am in /var/www/shop

This PR fix that ;)